### PR TITLE
Clean/Update + OnlyOffice reader instance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,11 +11,6 @@ build/
 coverage/
 
 
-# Locales
-**/locales/*
-!**/locales/en.json
-
-
 # transifex
 .transifexrc
 

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -6,10 +6,18 @@ import { Route, Switch, HashRouter } from 'react-router-dom'
 import { Layout, Main, Content } from 'cozy-ui/react/Layout'
 import { Sprite as IconSprite } from 'cozy-ui/react/Icon'
 
-import Editor from './Editor'
+import Editor from 'components/Editor'
 
 const useStyles = makeStyles(() => ({
-  appContent: {
+  layout: {
+    '&::before': {
+      display: 'none'
+    },
+    '&::after': {
+      display: 'none'
+    }
+  },
+  content: {
     height: '100%',
     alignItems: 'center',
     justifyContent: 'center'
@@ -21,10 +29,10 @@ const App = () => {
 
   return (
     <HashRouter>
-      <Layout>
+      <Layout className={styles.layout}>
         <Main>
           <style>#coz-bar {'{ display: none }'}</style>
-          <Content className={styles.appContent}>
+          <Content className={styles.content}>
             <Switch>
               <Route path="/:id" component={Editor} />
             </Switch>

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -2,9 +2,11 @@ import React from 'react'
 import { hot } from 'react-hot-loader'
 import { makeStyles } from '@material-ui/core/styles'
 
-import { HashRouter } from 'react-router-dom'
+import { Route, Switch, HashRouter } from 'react-router-dom'
 import { Layout, Main, Content } from 'cozy-ui/react/Layout'
 import { Sprite as IconSprite } from 'cozy-ui/react/Icon'
+
+import Editor from './Editor'
 
 const useStyles = makeStyles(() => ({
   appContent: {
@@ -22,7 +24,11 @@ const App = () => {
       <Layout>
         <Main>
           <style>#coz-bar {'{ display: none }'}</style>
-          <Content className={styles.appContent} />
+          <Content className={styles.appContent}>
+            <Switch>
+              <Route path="/:id" component={Editor} />
+            </Switch>
+          </Content>
         </Main>
         <IconSprite />
       </Layout>

--- a/src/components/Editor/Error.jsx
+++ b/src/components/Editor/Error.jsx
@@ -1,0 +1,15 @@
+import React from 'react'
+
+import Empty from 'cozy-ui/transpiled/react/Empty'
+import CozyIcon from 'cozy-ui/transpiled/react/Icons/Cozy'
+import { useI18n } from 'cozy-ui/react/I18n'
+
+const Error = () => {
+  const { t } = useI18n()
+
+  return (
+    <Empty icon={CozyIcon} title={t('Error.title')} text={t('Error.text')} />
+  )
+}
+
+export default Error

--- a/src/components/Editor/Loading.jsx
+++ b/src/components/Editor/Loading.jsx
@@ -1,0 +1,9 @@
+import React from 'react'
+
+import Spinner from 'cozy-ui/transpiled/react/Spinner'
+
+const Loading = () => {
+  return <Spinner size="xxlarge" />
+}
+
+export default Loading

--- a/src/components/Editor/View.jsx
+++ b/src/components/Editor/View.jsx
@@ -1,10 +1,12 @@
 import React, { useEffect, useCallback } from 'react'
 import { makeStyles } from '@material-ui/core/styles'
 
+import { headerHeight } from 'components/Header'
+
 const useStyles = makeStyles(() => ({
   container: {
     width: '100%',
-    height: '100%'
+    height: `calc(100vh - ${headerHeight})`
   }
 }))
 

--- a/src/components/Editor/View.jsx
+++ b/src/components/Editor/View.jsx
@@ -1,0 +1,40 @@
+import React, { useEffect, useCallback } from 'react'
+import { makeStyles } from '@material-ui/core/styles'
+
+const useStyles = makeStyles(() => ({
+  container: {
+    width: '100%',
+    height: '100%'
+  }
+}))
+
+const View = ({ apiUrl, config }) => {
+  const styles = useStyles()
+
+  const initEditor = useCallback(
+    () => {
+      new window.DocsAPI.DocEditor('onlyOfficeEditor', { ...config })
+    },
+    [config]
+  )
+
+  useEffect(
+    () => {
+      const script = document.createElement('script')
+      script.src = apiUrl
+      script.async = true
+      script.onload = () => initEditor()
+
+      document.body.appendChild(script)
+    },
+    [apiUrl, initEditor]
+  )
+
+  return (
+    <div className={styles.container}>
+      <div id="onlyOfficeEditor" />
+    </div>
+  )
+}
+
+export default View

--- a/src/components/Editor/index.jsx
+++ b/src/components/Editor/index.jsx
@@ -23,6 +23,8 @@ export const Editor = props => {
   // complete config doc : https://api.onlyoffice.com/editors/advanced
   const config = {
     document: onlyOffice.document,
+    editorConfig: onlyOffice.editor,
+    token: onlyOffice.token,
     documentType: onlyOffice.documentType
   }
 

--- a/src/components/Editor/index.jsx
+++ b/src/components/Editor/index.jsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { useClient } from 'cozy-client'
 
 import useDoc from 'hooks/useDoc'
+import Header from 'components/Header'
 import View from './View'
 import Error from './Error'
 import Loading from './Loading'
@@ -25,7 +26,12 @@ export const Editor = props => {
     documentType: onlyOffice.documentType
   }
 
-  return <View apiUrl={apiUrl} config={config} />
+  return (
+    <>
+      <Header title={onlyOffice.document.title} />
+      <View apiUrl={apiUrl} config={config} />
+    </>
+  )
 }
 
 export default Editor

--- a/src/components/Editor/index.jsx
+++ b/src/components/Editor/index.jsx
@@ -1,0 +1,31 @@
+import React from 'react'
+
+import { useClient } from 'cozy-client'
+
+import useDoc from 'hooks/useDoc'
+import View from './View'
+import Error from './Error'
+import Loading from './Loading'
+
+export const Editor = props => {
+  const client = useClient()
+  const { loading, doc } = useDoc({ client, fileId: props.match.params.id })
+
+  if (loading) return <Loading />
+  if (!doc) return <Error />
+
+  const { data } = doc
+  const onlyOffice = data.attributes.onlyoffice
+  const serverUrl = onlyOffice.url
+  const apiUrl = `${serverUrl}/web-apps/apps/api/documents/api.js`
+
+  // complete config doc : https://api.onlyoffice.com/editors/advanced
+  const config = {
+    document: onlyOffice.document,
+    documentType: onlyOffice.documentType
+  }
+
+  return <View apiUrl={apiUrl} config={config} />
+}
+
+export default Editor

--- a/src/components/Header/index.jsx
+++ b/src/components/Header/index.jsx
@@ -1,0 +1,44 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { makeStyles } from '@material-ui/core/styles'
+
+import IconButton from 'cozy-ui/transpiled/react/IconButton'
+import Icon from 'cozy-ui/transpiled/react/Icon'
+import PreviousIcon from 'cozy-ui/transpiled/react/Icons/Previous'
+import Typography from 'cozy-ui/transpiled/react/Typography'
+
+export const headerHeight = '3rem'
+
+const useStyles = makeStyles(() => ({
+  header: {
+    display: 'flex',
+    alignItems: 'center',
+    width: 'calc(100% - 2rem)',
+    height: headerHeight,
+    padding: '0 1rem'
+  }
+}))
+
+export const Header = ({ title, onClose }) => {
+  const styles = useStyles()
+
+  return (
+    <header className={styles.header}>
+      {onClose && (
+        <IconButton onClick={onClose}>
+          <Icon icon={PreviousIcon} />
+        </IconButton>
+      )}
+      <Typography className="u-pl-half" variant="h3" noWrap>
+        {title}
+      </Typography>
+    </header>
+  )
+}
+
+Header.propTypes = {
+  title: PropTypes.string.isRequired,
+  onClose: PropTypes.func
+}
+
+export default Header

--- a/src/hooks/useDoc.js
+++ b/src/hooks/useDoc.js
@@ -1,0 +1,50 @@
+import { useState, useEffect, useCallback } from 'react'
+
+import log from 'cozy-logger'
+
+const useDoc = ({ client, fileId }) => {
+  const [docId, setDocId] = useState(fileId)
+  const [loading, setLoading] = useState(true)
+  const [doc, setDoc] = useState(undefined)
+
+  const loadDoc = useCallback(
+    async () => {
+      try {
+        if (!loading) setLoading(true)
+        const doc = await client
+          .getStackClient()
+          .fetchJSON('GET', `/office/${docId}/open`)
+        setDoc(doc)
+      } catch (e) {
+        setDoc(false)
+        log('warn', `Could not load doc ${docId} : ${e}`)
+      }
+      setLoading(false)
+    },
+    [client, loading, docId]
+  )
+
+  useEffect(
+    () => {
+      if (docId !== fileId) {
+        // reload if ever fileId changes
+        setLoading(true)
+        setDoc(undefined)
+        setDocId(fileId)
+      } else if (client) {
+        // load the doc if needed
+        if (!doc || doc.data.id !== docId) {
+          loadDoc()
+        }
+      }
+    },
+    // `loadDoc` and `doc` are willingly not included in the dependencies
+    // since React as difficulties to manage complex objects as dependencies.
+    // We use docId instead
+    [client, fileId, docId, setDocId, setLoading, setDoc] // eslint-disable-line
+  )
+
+  return { loading, doc }
+}
+
+export default useDoc

--- a/src/hooks/useDoc.spec.js
+++ b/src/hooks/useDoc.spec.js
@@ -1,0 +1,88 @@
+import { renderHook } from '@testing-library/react-hooks'
+import { createMockClient } from 'cozy-client/dist/mock'
+
+import useDoc from './useDoc'
+import { officeDocParam } from '../../test/fixtures'
+
+const client = createMockClient({})
+const fileId = 'abc123'
+
+describe('useDoc', () => {
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('should call the stack with the correct route', async () => {
+    client.stackClient.fetchJSON.mockImplementation(() => officeDocParam)
+    const { waitForNextUpdate } = renderHook(() => useDoc({ client, fileId }))
+
+    await waitForNextUpdate()
+
+    const fetchJSON = client.stackClient.fetchJSON
+    const called = fetchJSON.mock.calls.length
+    const lastCall = fetchJSON.mock.calls[called - 1]
+
+    expect(client.stackClient.fetchJSON).toHaveBeenCalled()
+    expect(lastCall[0]).toBe('GET')
+    expect(lastCall[1]).toBe(`/office/${fileId}/open`)
+  })
+
+  it('should return the server response and no loading if everything goes right', async () => {
+    client.stackClient.fetchJSON.mockImplementation(() => officeDocParam)
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useDoc({ client, fileId })
+    )
+
+    expect(result.current.loading).toBeTruthy()
+    expect(result.current.doc).toBeUndefined()
+
+    await waitForNextUpdate()
+
+    expect(result.current.loading).toBeFalsy()
+    expect(result.current.doc).toMatchObject(officeDocParam)
+  })
+
+  it('should return error and no loading if something goes wrong', async () => {
+    const errorServerResponse = new Error('Oops')
+    client.stackClient.fetchJSON.mockImplementation(() => errorServerResponse)
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useDoc({ client, fileId })
+    )
+    await waitForNextUpdate()
+
+    const res = result.current
+    const { loading, doc } = res
+
+    expect(loading).toBeFalsy()
+    expect(doc).toMatchObject(errorServerResponse)
+  })
+
+  it('should return correct result after rerender with new props', async () => {
+    client.stackClient.fetchJSON.mockImplementation(() => officeDocParam)
+    let id = fileId
+    const { result, waitForNextUpdate, rerender } = renderHook(() =>
+      useDoc({ client, fileId: id })
+    )
+
+    expect(result.current.loading).toBeTruthy()
+    expect(result.current.doc).toBeUndefined()
+
+    await waitForNextUpdate()
+
+    expect(result.current.loading).toBeFalsy()
+    expect(result.current.doc).toMatchObject(officeDocParam)
+
+    id = '456'
+    client.stackClient.fetchJSON.mockImplementation(() => ({
+      data: { id: '456' }
+    }))
+    rerender()
+    expect(result.current.loading).toBeTruthy()
+    expect(result.current.doc).toBeUndefined()
+
+    await waitForNextUpdate()
+
+    expect(result.current.loading).toBeFalsy()
+    expect(result.current.doc).toMatchObject({ data: { id: '456' } })
+  })
+})

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -3,5 +3,9 @@
     "todos": "Todos",
     "hello_nav_2": "Second",
     "hello_nav_3": "Third"
+  },
+  "Error": {
+    "title": "Something goes wrong",
+    "text": "Please try to reload the page"
   }
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1,0 +1,6 @@
+{
+  "Error": {
+    "title": "Quelque chose n'a pas fonctionné",
+    "text": "Veuillez recharger la page"
+  }
+}

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -1,0 +1,35 @@
+export const officeDocParam = {
+  data: {
+    type: 'io.cozy.office.url',
+    id: '32e07d806f9b0139c541543d7eb8149c',
+    attributes: {
+      document_id: '32e07d806f9b0139c541543d7eb8149c',
+      subdomain: 'flat',
+      protocol: 'https',
+      instance: 'bob.cozy.example',
+      public_name: 'Bob',
+      onlyoffice: {
+        url: 'https://documentserver/',
+        documentType: 'word',
+        document: {
+          filetype: 'docx',
+          key:
+            '32e07d806f9b0139c541543d7eb8149c-56a653128a91a5c2291db9735b43fd86',
+          title: 'Letter.docx',
+          url:
+            'https://bob.cozy.example/files/downloads/735e6cf69af2db82/Letter.docx?Dl=1',
+          info: {
+            owner: 'Bob',
+            uploaded: '2010-07-07 3:46 PM'
+          }
+        },
+        editor: {
+          callbackUrl:
+            'https://bob.cozy.example/office/32e07d806f9b0139c541543d7eb8149c/callback',
+          lang: 'en',
+          mode: 'edit'
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Ajout d'un éditeur fullscreen (et d'un header) afin de visualiser les fichiers onlyoffice.

Comme il y a de forte chance pour que cette app disparaisse pour être rappatriée dans Drive, j'ai isolé la PR de l'éditeur de la PR de prépration de l'app (sur laquelle cette PR se base) : https://github.com/cozy/cozy-onlyoffice/pull/2

